### PR TITLE
🔧 setup test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,3 +58,41 @@ jobs:
           # delete the comment in case changes no longer impact gas costs
           delete: ${{ !steps.gas_diff.outputs.markdown }}
           message: ${{ steps.gas_diff.outputs.markdown }}
+
+  coverage:
+    needs: ["test"]
+    permissions: write-all
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Check out the repo"
+        uses: "actions/checkout@v3"
+        with:
+          submodules: "recursive"
+
+      - name: "Install Foundry"
+        uses: "foundry-rs/foundry-toolchain@v1"
+
+      - name: Setup lcov
+        uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: "Generate the coverage report"
+        # contracts in the test/ and script/ directory are excluded fron the report
+        # the precompute internal version of the library is also excluded from the report as
+        # it is highly experimental and to meant to be used at all
+        run: "forge coverage --report lcov && lcov --remove lcov.info \
+          -o lcov.info 'test/*' 'script/*'"
+
+      - name: "Add coverage summary"
+        run: |
+          echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v3
+        with:
+          coverage-files: lcov.info
+          # uncomment the following line to enforce a minimum coverage
+          # minimum-coverage: 80
+          artifact-name: code-coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          update-comment: true

--- a/README.md
+++ b/README.md
@@ -158,9 +158,7 @@ This template comes with GitHub Actions pre-configured.
 - [static-analysis.yml](./.github/workflows/static-analysis.yml): runs the static analysis tool on every push and pull
   request made to the `main` branch. This action uses [slither](https://github.com/crytic/slither) and is only triggered
   when specific files are modified.
-- [tests.yml](./.github/workflows/tests.yml): runs the tests onsevery push and pull request made to the `main` branch.
-  This action also compare the gas cost between the `main` branch and the pull request branch and post the difference as
-  a comment on the pull request.
+- [tests.yml](./.github/workflows/tests.yml): runs the tests on every push and pull request made to the `main` branch. This action also compare the gas cost between the `main` branch and the pull request branch and post the difference as a comment on the pull request. Finally this action check the code coverage and post the result as a comment on the pull request. A threshold can be configured by unchecking the concerned line in the workflow file. This workflow uses [lcov](https://github.com/linux-test-project/lcov) for the coverage.
 - [release-package.yml](./.github/workflows/release-package.yml): creates a new release every time you push a new tag to
   the repository. This action is only triggered on tags starting with `v`. Once the release is created, the action is
   also in charge of deploying the documentation to the `gh-pages` branch. **THIS ACTION NEEDS AN ACTION FROM YOUR SIDE


### PR DESCRIPTION
Setup a GitHub workflow that checks code coverage. The threshold is commented by default.